### PR TITLE
Refactor: Apply Clean Architecture and SOLID principles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,14 +245,17 @@ dependencies = [
 name = "create_lgtm_image"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "base64",
  "image",
  "imageproc",
+ "mockall",
  "reqwest",
  "rusttype",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio 1.45.1",
  "tower-http",
 ]
@@ -283,15 +298,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "downcast"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -387,6 +397,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -513,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
 dependencies = [
  "cfg-if 1.0.0",
  "crunchy",
@@ -650,110 +666,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
-
-[[package]]
-name = "icu_properties"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "potential_utf",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
-
-[[package]]
-name = "icu_provider"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -892,12 +811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
-name = "litemap"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +917,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multer"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,10 +977,11 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1308,21 +1248,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "potential_utf"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1698,12 +1655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,17 +1672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1682,32 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1756,14 +1722,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.1"
+name = "tinyvec"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
- "displaydoc",
- "zerovec",
+ "tinyvec_macros",
 ]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1957,27 +1928,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "url"
-version = "2.5.4"
+name = "unicode-normalization"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -2255,12 +2235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,30 +2242,6 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -2308,60 +2258,6 @@ name = "zerocopy-derive"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ reqwest = { version = "=0.10.10", features = ["blocking", "json" ] } # Pinned to
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.13"
+anyhow = "1.0.98"
+thiserror = "2.0.12"
+
+[dev-dependencies]
+mockall = "0.13.1"

--- a/src/create_lgtm_image/application/error.rs
+++ b/src/create_lgtm_image/application/error.rs
@@ -1,0 +1,63 @@
+use thiserror::Error;
+use crate::domain::error::DomainError; // ドメインエラーをラップするため
+use crate::infrastructure::error::InfrastructureError; // InfrastructureError をラップするため
+
+#[derive(Error, Debug)]
+pub enum ApplicationError {
+    #[error("LGTM generation failed: {0}")]
+    LgtmGenerationFailed(String),
+
+    #[error("External service error: {0}")]
+    ExternalServiceError(String),
+
+    #[error("Configuration error: {0}")]
+    ConfigurationError(String),
+
+    #[error("Domain error occurred: {0}")]
+    DomainError(#[from] DomainError), // ドメインエラーをラップ
+
+    #[error("Infrastructure error occurred: {0}")]
+    InfrastructureError(#[from] InfrastructureError), // InfrastructureError をラップ
+
+    #[error("Underlying error: {source:?}")]
+    AnyhowError {
+        #[from]
+        source: anyhow::Error,
+    }
+}
+
+// IntoResponse implementation for ApplicationError
+use axum::response::{IntoResponse, Response};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::json;
+
+impl IntoResponse for ApplicationError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = match self {
+            ApplicationError::LgtmGenerationFailed(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            ApplicationError::ExternalServiceError(msg) => (StatusCode::BAD_GATEWAY, msg),
+            ApplicationError::ConfigurationError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            ApplicationError::DomainError(domain_err) => {
+                (StatusCode::BAD_REQUEST, domain_err.to_string())
+            }
+            ApplicationError::InfrastructureError(infra_err) => {
+                // Log the full infra_err for detailed debugging if possible
+                eprintln!("InfrastructureError: {:?}", infra_err);
+                // You might want to map specific infra errors to different status codes
+                match infra_err {
+                    InfrastructureError::ExternalApiError(_) => (StatusCode::BAD_GATEWAY, infra_err.to_string()),
+                    InfrastructureError::DecodingError(_) => (StatusCode::BAD_REQUEST, infra_err.to_string()),
+                    InfrastructureError::ImageLibError(_) => (StatusCode::UNPROCESSABLE_ENTITY, infra_err.to_string()),
+                    _ => (StatusCode::INTERNAL_SERVER_ERROR, infra_err.to_string()),
+                }
+            }
+            ApplicationError::AnyhowError{source} => {
+                eprintln!("Unhandled AnyhowError: {:?}", source); // ログ出力
+                (StatusCode::INTERNAL_SERVER_ERROR, "An unexpected error occurred.".to_string())
+            }
+        };
+        let body = Json(json!({ "error": error_message }));
+        (status, body).into_response()
+    }
+}

--- a/src/create_lgtm_image/application/lgtm_service.rs
+++ b/src/create_lgtm_image/application/lgtm_service.rs
@@ -1,0 +1,205 @@
+use std::sync::Arc;
+// use anyhow::Result; // Remove if fully transitioned
+use super::error::ApplicationError; // Changed from anyhow::Result
+use image::ImageFormat as InnerImageFormat;
+
+use crate::domain::image_processor_trait::ImageProcessor;
+use crate::domain::text_overlay::TextOverlay;
+use crate::domain::color::Color as DomainColor;
+use crate::domain::position::Position as DomainPosition;
+// external_image_fetcherもインフラ層なので、トレイト経由でDIするのが望ましいが、今回は直接使う
+use crate::infrastructure::external_image_fetcher::DefaultExternalImageFetcher;
+
+
+pub struct LgtmService {
+    image_processor: Arc<dyn ImageProcessor + Send + Sync>, // トレイトオブジェクトとして保持
+    // external_image_fetcher: Arc<dyn ExternalImageFetcherTrait + Send + Sync>, // 本来はこうしたい
+}
+
+impl LgtmService {
+    pub fn new(image_processor: Arc<dyn ImageProcessor + Send + Sync>) -> Self {
+        Self { image_processor }
+    }
+
+    fn map_position_str_to_domain(&self, position_str: &str) -> DomainPosition {
+        match position_str.to_lowercase().as_str() {
+            "top-left" => DomainPosition::TopLeft,
+            "top-center" => DomainPosition::TopCenter,
+            "top-right" => DomainPosition::TopRight,
+            "center-left" => DomainPosition::CenterLeft,
+            "center" => DomainPosition::Center,
+            "center-right" => DomainPosition::CenterRight,
+            "bottom-left" => DomainPosition::BottomLeft,
+            "bottom-center" => DomainPosition::BottomCenter,
+            "bottom-right" => DomainPosition::BottomRight,
+            _ => DomainPosition::Center, // Default
+        }
+    }
+
+    fn map_format_str_to_enum(&self, format_str: &str) -> (InnerImageFormat, &'static str) {
+        match format_str.to_lowercase().as_str() {
+            "jpeg" | "jpg" => (InnerImageFormat::Jpeg, "image/jpeg"),
+            "png" | _ => (InnerImageFormat::Png, "image/png"), // Default to PNG
+        }
+    }
+
+    pub async fn generate_lgtm_image(
+        &self,
+        image_data: Vec<u8>,
+        text: String,
+        text_color_hex: String,
+        text_position_str: String,
+        output_format_str: String, // 出力フォーマット指定を追加
+    ) -> Result<(Vec<u8>, &'static str), ApplicationError> { // Changed to ApplicationError
+        println!("LgtmService: generate_lgtm_image called with format: {}", output_format_str);
+
+        let color = self.image_processor.parse_hex_color(&text_color_hex);
+        let position = self.map_position_str_to_domain(&text_position_str);
+
+        let text_overlay = TextOverlay {
+            text,
+            color,
+            position,
+        };
+
+        let (output_format_enum, content_type) = self.map_format_str_to_enum(&output_format_str);
+
+        let processed_image_bytes = self.image_processor.add_text_to_image(
+            image_data,
+            None, // image_data からフォーマットを推測させる
+            &text_overlay,
+            output_format_enum,
+        )?;
+
+        Ok((processed_image_bytes, content_type))
+    }
+
+    pub async fn generate_lgtm_image_from_url(
+        &self,
+        image_url: String,
+        text: String,
+        text_color_hex: String,
+        text_position_str: String,
+        output_format_str: String,
+    ) -> Result<(Vec<u8>, &'static str), ApplicationError> { // Changed to ApplicationError
+        println!("LgtmService: generate_lgtm_image_from_url called for URL: {}", image_url);
+
+        // インフラ層の具体的な fetcher を直接利用 (DIするのが望ましい)
+        let image_fetcher = DefaultExternalImageFetcher::new();
+        let image_data = image_fetcher.fetch_image_from_url_impl(&image_url).await?;
+
+        self.generate_lgtm_image(
+            image_data,
+            text,
+            text_color_hex,
+            text_position_str,
+            output_format_str
+        ).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::image_processor_trait::ImageProcessor;
+    use crate::infrastructure::error::InfrastructureError; // ImageProcessorモックが返すエラー用
+    use crate::domain::text_overlay::TextOverlay as DomainTextOverlayFull; // Renamed to avoid conflict
+    use image::ImageFormat as InnerImageFormat; // モック内で使うため
+    use std::sync::{Arc, Mutex};
+
+    // 手動モック: ImageProcessor トレイトのテスト用実装
+    #[derive(Clone)]
+    struct MockImageProcessor {
+        add_text_result: Arc<Mutex<Result<Vec<u8>, String>>>, // Error type is String for easier mocking
+        parse_color_result: Arc<Mutex<DomainColor>>,
+        add_text_called: Arc<Mutex<bool>>,
+        last_text_overlay: Arc<Mutex<Option<DomainTextOverlayFull>>>
+    }
+
+    impl ImageProcessor for MockImageProcessor {
+        fn add_text_to_image(
+            &self,
+            _image_bytes: Vec<u8>,
+            _input_format_opt: Option<InnerImageFormat>,
+            text_overlay: &DomainTextOverlayFull,
+            _output_format: InnerImageFormat,
+        ) -> Result<Vec<u8>, InfrastructureError> {
+            let mut called_flag = self.add_text_called.lock().unwrap();
+            *called_flag = true;
+            let mut last_overlay_lock = self.last_text_overlay.lock().unwrap();
+            *last_overlay_lock = Some(text_overlay.clone());
+
+            self.add_text_result.lock().unwrap().as_ref()
+                .map(|v| v.clone())
+                .map_err(|s| InfrastructureError::ImageProcessingError(s.clone()))
+        }
+
+        fn parse_hex_color(&self, _hex_str: &str) -> DomainColor {
+            self.parse_color_result.lock().unwrap().clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generate_lgtm_image_success() {
+        let mock_image_processor = Arc::new(MockImageProcessor {
+            add_text_result: Arc::new(Mutex::new(Ok(vec![1, 2, 3]))),
+            parse_color_result: Arc::new(Mutex::new(DomainColor::new(0,0,0,255))),
+            add_text_called: Arc::new(Mutex::new(false)),
+            last_text_overlay: Arc::new(Mutex::new(None)),
+        });
+
+        let service = LgtmService::new(mock_image_processor.clone());
+
+        let image_data = vec![4, 5, 6];
+        let result = service.generate_lgtm_image(
+            image_data,
+            "Test".to_string(),
+            "#000000".to_string(),
+            "center".to_string(),
+            "png".to_string()
+        ).await;
+
+        assert!(result.is_ok());
+        let (data, content_type) = result.unwrap();
+        assert_eq!(data, vec![1, 2, 3]);
+        assert_eq!(content_type, "image/png");
+        assert!(*mock_image_processor.add_text_called.lock().unwrap());
+
+        let overlay_used = mock_image_processor.last_text_overlay.lock().unwrap();
+        assert!(overlay_used.is_some());
+        assert_eq!(overlay_used.as_ref().unwrap().text, "Test");
+    }
+
+    #[tokio::test]
+    async fn test_generate_lgtm_image_processor_fails() {
+        let mock_image_processor = Arc::new(MockImageProcessor {
+             add_text_result: Arc::new(Mutex::new(Err("mock processing error".to_string()))),
+             parse_color_result: Arc::new(Mutex::new(DomainColor::new(0,0,0,255))),
+             add_text_called: Arc::new(Mutex::new(false)),
+             last_text_overlay: Arc::new(Mutex::new(None)),
+        });
+        let service = LgtmService::new(mock_image_processor);
+
+        let image_data = vec![4, 5, 6];
+        let result = service.generate_lgtm_image(
+            image_data,
+            "Test".to_string(),
+            "#000000".to_string(),
+            "center".to_string(),
+            "png".to_string()
+        ).await;
+
+        assert!(result.is_err());
+        match result.err().unwrap() {
+            ApplicationError::InfrastructureError(infra_err) => {
+                match infra_err {
+                    InfrastructureError::ImageProcessingError(msg) => {
+                        assert_eq!(msg, "mock processing error");
+                    }
+                    _ => panic!("Expected InfrastructureError::ImageProcessingError variant, got {:?}", infra_err),
+                }
+            }
+            e => panic!("Expected ApplicationError::InfrastructureError, got {:?}", e),
+        }
+    }
+}

--- a/src/create_lgtm_image/application/mod.rs
+++ b/src/create_lgtm_image/application/mod.rs
@@ -1,0 +1,2 @@
+pub mod lgtm_service;
+pub mod error;

--- a/src/create_lgtm_image/domain/color.rs
+++ b/src/create_lgtm_image/domain/color.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+impl Color {
+    pub fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
+}

--- a/src/create_lgtm_image/domain/error.rs
+++ b/src/create_lgtm_image/domain/error.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DomainError {
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+    // 必要に応じてドメイン固有のエラーを追加
+    // 例: #[error("Color parsing failed: {0}")]
+    //     ColorParseError(String),
+}

--- a/src/create_lgtm_image/domain/image.rs
+++ b/src/create_lgtm_image/domain/image.rs
@@ -1,0 +1,19 @@
+use image::ImageFormat; // Assuming ImageFormat will be used from the image crate
+
+pub struct Image {
+    pub data: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub format: ImageFormat,
+}
+
+impl Image {
+    pub fn new(data: Vec<u8>, width: u32, height: u32, format: ImageFormat) -> Self {
+        Self {
+            data,
+            width,
+            height,
+            format,
+        }
+    }
+}

--- a/src/create_lgtm_image/domain/image_processor_trait.rs
+++ b/src/create_lgtm_image/domain/image_processor_trait.rs
@@ -1,0 +1,20 @@
+use crate::domain::image::Image as DomainImage;
+use crate::domain::text_overlay::TextOverlay as DomainTextOverlay;
+use crate::domain::color::Color as DomainColor; // 追加
+use crate::domain::position::Position as DomainPosition; // 追加
+use crate::infrastructure::error::InfrastructureError; // Changed from DomainError
+// use anyhow::Result; // Removed as no longer directly used by trait methods
+use image::ImageFormat as InnerImageFormat; // imageクレートのImageFormatをインポート
+
+// このトレイトは、ドメインの型を受け取り、ドメインの型または結果を返す
+pub trait ImageProcessor {
+    fn add_text_to_image(
+        &self,
+        image_bytes: Vec<u8>,
+        input_format_opt: Option<InnerImageFormat>,
+        text_overlay: &DomainTextOverlay,
+        output_format: InnerImageFormat,
+    ) -> Result<Vec<u8>, InfrastructureError>; // Changed to InfrastructureError
+
+    fn parse_hex_color(&self, hex_str: &str) -> DomainColor;
+}

--- a/src/create_lgtm_image/domain/mod.rs
+++ b/src/create_lgtm_image/domain/mod.rs
@@ -1,0 +1,6 @@
+pub mod image;
+pub mod text_overlay;
+pub mod color;
+pub mod position;
+pub mod image_processor_trait;
+pub mod error;

--- a/src/create_lgtm_image/domain/position.rs
+++ b/src/create_lgtm_image/domain/position.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum Position {
+    TopLeft,
+    TopCenter,
+    TopRight,
+    CenterLeft,
+    Center,
+    CenterRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+    Custom { x: u32, y: u32 },
+}

--- a/src/create_lgtm_image/domain/text_overlay.rs
+++ b/src/create_lgtm_image/domain/text_overlay.rs
@@ -1,0 +1,19 @@
+use crate::domain::color::Color;
+use crate::domain::position::Position;
+
+#[derive(Clone, Debug)]
+pub struct TextOverlay {
+    pub text: String,
+    pub color: Color,
+    pub position: Position,
+}
+
+impl TextOverlay {
+    pub fn new(text: String, color: Color, position: Position) -> Self {
+        Self {
+            text,
+            color,
+            position,
+        }
+    }
+}

--- a/src/create_lgtm_image/infrastructure/axum_handler.rs
+++ b/src/create_lgtm_image/infrastructure/axum_handler.rs
@@ -1,0 +1,114 @@
+use crate::application::error::ApplicationError; // Added for handler return types
+use axum::{
+    body::Body,
+    extract::{Multipart, Query, Json, State},
+    http::{self, StatusCode, header::HeaderName},
+    response::{IntoResponse, Response},
+};
+use serde::Deserialize;
+use std::sync::Arc;
+// TokioFile, AsyncWriteExt, Cursor は upload_image_handler で一時ファイル保存が残るなら必要
+use tokio::fs::File as TokioFile;
+use tokio::io::AsyncWriteExt;
+// use std::io::Cursor; // LgtmService がバイト列を直接扱うので、ハンドラでは不要になることが多い
+
+use crate::application::lgtm_service::LgtmService;
+// LocalFileStorage の use は preview/download が直接ファイルを読むなら必要
+
+#[derive(Clone)]
+pub struct AppState {
+    pub lgtm_service: Arc<LgtmService>,
+    // pub file_storage: Arc<LocalFileStorage>, // 必要に応じて
+}
+
+// FetchImageParams DTO はここ
+#[derive(Deserialize, Debug)]
+pub struct FetchImageParams {
+    pub url: String,
+    pub text: Option<String>,
+    #[serde(rename = "textColor")]
+    pub text_color: Option<String>,
+    #[serde(rename = "textPosition")]
+    pub text_position: Option<String>,
+    #[serde(rename = "outputFormat")]
+    pub output_format: Option<String>,
+}
+
+pub async fn upload_image_handler(
+    State(state): State<Arc<AppState>>,
+    mut multipart: Multipart,
+) -> Result<impl IntoResponse, ApplicationError> { // Changed to ApplicationError
+    // Simplified error handling for multipart processing for this step
+    // Proper error mapping from multipart errors to ApplicationError would be more robust
+    while let Some(field) = multipart.next_field().await.map_err(|e| ApplicationError::LgtmGenerationFailed(format!("Multipart error: {}", e)))? {
+        let data = field.bytes().await.map_err(|e| ApplicationError::LgtmGenerationFailed(format!("Failed to read bytes from multipart field: {}", e)))?;
+
+        let text = "LGTM".to_string(); // Default text
+        let text_color_hex = "#FFFFFFFF".to_string(); // Default color
+        let text_position_str = "center".to_string(); // Default position
+        let output_format_str = "png".to_string(); // Default output format
+
+        let (processed_image_data, _content_type) = state.lgtm_service.generate_lgtm_image(
+            data.to_vec(),
+            text,
+            text_color_hex,
+            text_position_str,
+            output_format_str, // "png"
+        ).await?; // Use `?` due to `From<ApplicationError>` for `InfrastructureError`
+
+        // TODO: ファイル保存は FileStorage サービス経由にしたい
+        // For now, map IO errors to ApplicationError::InfrastructureError manually or via a helper
+        let mut file = TokioFile::create("output.png").await.map_err(|e| ApplicationError::InfrastructureError(super::error::InfrastructureError::IoError(e)))?;
+        file.write_all(&processed_image_data).await.map_err(|e| ApplicationError::InfrastructureError(super::error::InfrastructureError::IoError(e)))?;
+    }
+
+    Ok("画像アップロード完了".to_string())
+}
+
+pub async fn preview_image_handler(
+) -> Result<impl IntoResponse, ApplicationError> { // Changed to ApplicationError
+    let image_path = "output.png";
+    let image_data = tokio::fs::read(image_path).await.map_err(|e| ApplicationError::InfrastructureError(super::error::InfrastructureError::IoError(e)))?;
+
+    Response::builder()
+        .header("Content-Type", "image/png")
+        .body(Body::from(image_data))
+        .map_err(|e| ApplicationError::LgtmGenerationFailed(format!("Failed to build preview response: {}", e)))
+}
+
+pub async fn download_image_handler(
+) -> Result<impl IntoResponse, ApplicationError> { // Changed to ApplicationError
+    let image_path = "output.png";
+    let image_data = tokio::fs::read(image_path)
+        .await
+        .map_err(|e| ApplicationError::InfrastructureError(super::error::InfrastructureError::IoError(e)))?;
+
+    Response::builder()
+        .header("Content-Type", "image/png")
+        .header("Content-Disposition", "attachment; filename=\"downloaded_image.png\"")
+        .body(Body::from(image_data))
+        .map_err(|e| ApplicationError::LgtmGenerationFailed(format!("Failed to build download response: {}", e)))
+}
+
+pub async fn fetch_image_handler(
+    State(state): State<Arc<AppState>>,
+    Json(params): Json<FetchImageParams>,
+) -> Result<impl IntoResponse, ApplicationError> { // Changed to ApplicationError
+    let actual_text = params.text.unwrap_or_else(|| "LGTM".to_string());
+    let actual_color_hex = params.text_color.unwrap_or_else(|| "#FFFFFFFF".to_string());
+    let actual_position_str = params.text_position.unwrap_or_else(|| "center".to_string());
+    let desired_format_str = params.output_format.unwrap_or_else(|| "png".to_string());
+
+    let (processed_image_data, content_type) = state.lgtm_service.generate_lgtm_image_from_url(
+        params.url,
+        actual_text,
+        actual_color_hex,
+        actual_position_str,
+        desired_format_str,
+    ).await?; // Use `?`
+
+    Response::builder()
+        .header("Content-Type", content_type)
+        .body(Body::from(processed_image_data))
+        .map_err(|e| ApplicationError::LgtmGenerationFailed(format!("Failed to build fetch response: {}", e)))
+}

--- a/src/create_lgtm_image/infrastructure/error.rs
+++ b/src/create_lgtm_image/infrastructure/error.rs
@@ -1,0 +1,39 @@
+use thiserror::Error;
+use crate::domain::error::DomainError; // ImageProcessorの実装でDomainErrorを返すことがあるため
+
+#[derive(Error, Debug)]
+pub enum InfrastructureError {
+    #[error("Image processing failed: {0}")]
+    ImageProcessingError(String),
+
+    #[error("File storage error: {0}")]
+    FileStorageError(String),
+
+    #[error("External API call failed: {0}")]
+    ExternalApiError(String),
+
+    #[error("Data decoding failed: {0}")]
+    DecodingError(String),
+
+    #[error("Underlying image library error")]
+    ImageLibError(#[from] image::ImageError), // image::ImageError をラップ
+
+    #[error("Underlying I/O error")]
+    IoError(#[from] std::io::Error), // std::io::Error をラップ
+
+    #[error("Reqwest error")]
+    ReqwestError(#[from] reqwest::Error), // reqwest::Error をラップ
+
+    #[error("Base64 decode error")]
+    Base64DecodeError(#[from] base64::DecodeError),
+
+    // ドメインエラーをラップする場合 (ImageProcessorの実装がDomainErrorを返す場合など)
+    // これは通常、ImageProcessorトレイトのメソッドがDomainErrorを返し、
+    // その実装であるDefaultImageProcessorがそれをそのまま返すか、
+    // InfrastructureErrorに変換する場合に使用します。
+    // 今回の設計ではImageProcessorトレイトがInfrastructureErrorを返すようにしたので、
+    // このDomainErrorWrapperは直接的には使われないかもしれません。
+    // しかし、他のインフラコンポーネントがドメインサービスを呼び、それがDomainErrorを返す場合には有用です。
+    #[error("Domain Error Wrapper: {0}")]
+    DomainErrorWrapper(#[from] DomainError),
+}

--- a/src/create_lgtm_image/infrastructure/external_image_fetcher.rs
+++ b/src/create_lgtm_image/infrastructure/external_image_fetcher.rs
@@ -1,0 +1,29 @@
+use super::error::InfrastructureError; // Changed from anyhow::Result
+// use anyhow::Result; // Remove if fully transitioned
+use reqwest;
+use base64::decode; // main.rs から移動
+
+// ドメイン層で定義する ExternalImageFetcher トレイトの具体的な実装
+/*
+pub trait ExternalImageFetcher {
+    async fn fetch_image_from_url(&self, url: &str) -> Result<Vec<u8>>;
+}
+*/
+
+pub struct DefaultExternalImageFetcher;
+
+impl DefaultExternalImageFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn fetch_image_from_url_impl(&self, url: &str) -> Result<Vec<u8>, InfrastructureError> { // Changed to InfrastructureError
+        if url.starts_with("data:") {
+            let base64_data = url.split(',').nth(1).ok_or_else(|| InfrastructureError::DecodingError("Invalid data URL: missing comma".to_string()))?;
+            Ok(decode(base64_data).map_err(InfrastructureError::Base64DecodeError)?)
+        } else {
+            let response = reqwest::get(url).await.map_err(InfrastructureError::ReqwestError)?;
+            Ok(response.bytes().await.map_err(InfrastructureError::ReqwestError)?.to_vec())
+        }
+    }
+}

--- a/src/create_lgtm_image/infrastructure/file_storage.rs
+++ b/src/create_lgtm_image/infrastructure/file_storage.rs
@@ -1,0 +1,32 @@
+use super::error::InfrastructureError; // Changed from anyhow::Result
+// use anyhow::Result; // Remove if fully transitioned
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::fs; // fs::read を使うために追加
+
+// ドメイン層で定義する FileStorage トレイトの具体的な実装
+/*
+pub trait FileStorage {
+    async fn save_image(&self, path: &str, data: &[u8]) -> Result<()>;
+    async fn read_image(&self, path: &str) -> Result<Vec<u8>>;
+}
+*/
+
+pub struct LocalFileStorage;
+
+impl LocalFileStorage {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn save_image_impl(&self, path: &str, data: &[u8]) -> Result<(), InfrastructureError> { // Changed to InfrastructureError
+        let mut file = File::create(path).await.map_err(InfrastructureError::IoError)?;
+        file.write_all(data).await.map_err(InfrastructureError::IoError)?;
+        Ok(())
+    }
+
+    pub async fn read_image_impl(&self, path: &str) -> Result<Vec<u8>, InfrastructureError> { // Changed to InfrastructureError
+        let data = fs::read(path).await.map_err(InfrastructureError::IoError)?;
+        Ok(data)
+    }
+}

--- a/src/create_lgtm_image/infrastructure/image_processor.rs
+++ b/src/create_lgtm_image/infrastructure/image_processor.rs
@@ -1,0 +1,223 @@
+use crate::domain::image_processor_trait::ImageProcessor;
+use crate::domain::image::Image as DomainImage; // Keep if used, or remove
+use crate::domain::text_overlay::TextOverlay as DomainTextOverlay;
+use crate::domain::color::Color as DomainColor;
+use crate::domain::position::Position as DomainPosition;
+use super::error::InfrastructureError; // Changed from anyhow::Result
+// use anyhow::Result; // Remove if fully transitioned
+use crate::domain::error::DomainError; // Not directly used in signature, but good for context
+use image::{Rgba, RgbaImage, ImageFormat as InnerImageFormat}; // imageクレートの型
+use imageproc::drawing::draw_text_mut;
+use rusttype::{Font, Scale, point};
+use std::io::Cursor;
+
+// ドメイン層で定義する ImageProcessor トレイトの具体的な実装
+// (トレイトの定義はドメイン層で行うが、ここでは仮で Trait をコメントアウトで記述)
+/*
+pub trait ImageProcessor {
+    fn add_text_to_image(
+        &self,
+        image: DomainImage,
+        text_overlay: DomainTextOverlay,
+    ) -> Result<DomainImage>;
+}
+*/
+
+pub struct DefaultImageProcessor;
+
+impl DefaultImageProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ImageProcessor for DefaultImageProcessor {
+    // main.rs の add_text と parse_hex_color をここに移植・統合する
+    // 入力はドメインの型、出力もドメインの型とする
+    fn add_text_to_image(
+        &self,
+        image_bytes: Vec<u8>, // 元の画像のバイト列
+        input_format_opt: Option<InnerImageFormat>, // 元の画像のフォーマット (推測に任せる場合はNone)
+        text_overlay: &DomainTextOverlay,
+        output_format: InnerImageFormat,
+    ) -> Result<Vec<u8>, InfrastructureError> { // Changed to InfrastructureError
+        let reader = match input_format_opt {
+            Some(format) => image::io::Reader::with_format(Cursor::new(image_bytes), format),
+            None => image::io::Reader::new(Cursor::new(image_bytes)).with_guessed_format().map_err(InfrastructureError::IoError)?,
+        };
+        let mut img = reader.decode().map_err(InfrastructureError::ImageLibError)?.to_rgba8();
+
+        let font_data = include_bytes!("../../../DejaVu_Sans/DejaVuSans-Bold.ttf");
+        let font = Font::try_from_bytes(font_data).ok_or_else(|| InfrastructureError::ImageProcessingError("Failed to load font".to_string()))?;
+
+        let color = Rgba([
+            text_overlay.color.r,
+            text_overlay.color.g,
+            text_overlay.color.b,
+            text_overlay.color.a,
+        ]);
+
+        // テキストのスケールと位置計算 (main.rs のロジックを適用)
+        // この部分は main.rs の add_text 関数のロジックをほぼそのまま持ってくる
+        // ただし、入力として DomainTextOverlay の position を使う
+        let text = &text_overlay.text;
+        let mut current_scale_val = if text.len() > 20 {
+            img.height() as f32 / (text.len() as f32 / 2.5)
+        } else if text.len() > 10 {
+            img.height() as f32 / (text.len() as f32 / 1.8)
+        } else {
+            img.height() as f32 / 5.0
+        };
+        if current_scale_val < 1.0 { current_scale_val = 1.0; }
+        let mut scale = Scale::uniform(current_scale_val);
+        let mut v_metrics = font.v_metrics(scale);
+        let mut glyphs: Vec<_> = font.layout(text, scale, point(0.0, 0.0)).collect();
+        let mut text_width = glyphs.iter().filter_map(|g| g.pixel_bounding_box()).map(|bb| bb.max.x as f32).last().unwrap_or(0.0);
+        let mut text_height = v_metrics.ascent - v_metrics.descent;
+
+        let max_text_width_ratio = 0.90;
+        if text_width > img.width() as f32 * max_text_width_ratio && text_width > 0.0 {
+            let new_scale_factor = (img.width() as f32 * max_text_width_ratio) / text_width;
+            current_scale_val *= new_scale_factor;
+            if current_scale_val < 1.0 { current_scale_val = 1.0; }
+            scale = Scale::uniform(current_scale_val);
+            v_metrics = font.v_metrics(scale);
+            glyphs = font.layout(text, scale, point(0.0, 0.0)).collect();
+            text_width = glyphs.iter().filter_map(|g| g.pixel_bounding_box()).map(|bb| bb.max.x as f32).last().unwrap_or(0.0);
+            text_height = v_metrics.ascent - v_metrics.descent;
+        }
+
+        let final_scale = scale;
+        let v_metrics_final = v_metrics;
+        let actual_text_glyph_height = text_height;
+
+        let (mut x_pos, mut y_pos_base) = match text_overlay.position {
+            DomainPosition::TopLeft => (0.0, 0.0),
+            DomainPosition::TopCenter => ((img.width() as f32 - text_width) / 2.0, 0.0),
+            DomainPosition::TopRight => (img.width() as f32 - text_width, 0.0),
+            DomainPosition::CenterLeft => (0.0, (img.height() as f32 - actual_text_glyph_height) / 2.0),
+            DomainPosition::Center | DomainPosition::Custom { .. } => ((img.width() as f32 - text_width) / 2.0, (img.height() as f32 - actual_text_glyph_height) / 2.0), // Customは一旦Centerと同じ扱い
+            DomainPosition::CenterRight => (img.width() as f32 - text_width, (img.height() as f32 - actual_text_glyph_height) / 2.0),
+            DomainPosition::BottomLeft => (0.0, img.height() as f32 - actual_text_glyph_height),
+            DomainPosition::BottomCenter => ((img.width() as f32 - text_width) / 2.0, img.height() as f32 - actual_text_glyph_height),
+            DomainPosition::BottomRight => (img.width() as f32 - text_width, img.height() as f32 - actual_text_glyph_height),
+        };
+        if x_pos < 0.0 { x_pos = 0.0; }
+        if y_pos_base < 0.0 {y_pos_base = 0.0; }
+        let y_pos = y_pos_base + v_metrics_final.ascent;
+
+        draw_text_mut(&mut img, color, x_pos as i32, y_pos as i32, final_scale, &font, text);
+
+        let mut buffer = Cursor::new(Vec::new());
+        img.write_to(&mut buffer, output_format).map_err(InfrastructureError::ImageLibError)?;
+        Ok(buffer.into_inner())
+    }
+
+    // main.rs の parse_hex_color をここに移植
+    fn parse_hex_color(&self, hex_str: &str) -> DomainColor {
+        let hex = hex_str.trim_start_matches('#');
+        let default_color = DomainColor::new(255, 255, 255, 255); // White
+
+        match hex.len() {
+            6 => { // RRGGBB
+                let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255);
+                let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255);
+                let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255);
+                DomainColor::new(r, g, b, 255)
+            }
+            8 => { // RRGGBBAA
+                let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255);
+                let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255);
+                let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255);
+                let a = u8::from_str_radix(&hex[6..8], 16).unwrap_or(255);
+                DomainColor::new(r, g, b, a)
+            }
+            _ => default_color,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::color::Color as DomainColor;
+    use crate::domain::position::Position as DomainPosition;
+    use crate::domain::text_overlay::TextOverlay;
+    use image::ImageFormat; // image クレートの ImageFormat
+    use crate::infrastructure::error::InfrastructureError; // For error matching
+
+    // parse_hex_color のテスト
+    #[test]
+    fn test_parse_hex_color_valid_formats() {
+        let processor = DefaultImageProcessor::new();
+        assert_eq!(processor.parse_hex_color("#FF0000"), DomainColor::new(255, 0, 0, 255));
+        assert_eq!(processor.parse_hex_color("00FF00"), DomainColor::new(0, 255, 0, 255));
+        assert_eq!(processor.parse_hex_color("#0000FF80"), DomainColor::new(0, 0, 255, 128));
+    }
+
+    #[test]
+    fn test_parse_hex_color_invalid_formats() {
+        let processor = DefaultImageProcessor::new();
+        let default_white = DomainColor::new(255, 255, 255, 255);
+        assert_eq!(processor.parse_hex_color("invalid"), default_white);
+        assert_eq!(processor.parse_hex_color("#123"), default_white);
+        assert_eq!(processor.parse_hex_color(""), default_white);
+    }
+
+    // add_text_to_image の基本的なテスト (エラーにならないこと、バイト列が返ること)
+    // このテストでは、実際に生成された画像の内容までは検証しない (それはより複雑なセットアップが必要)
+    #[test]
+    fn test_add_text_to_image_runs_without_error() {
+        let processor = DefaultImageProcessor::new();
+        // ダミーの画像データ (小さな透明なPNG)
+        // 1x1の透明なPNGのBase64エンコードデータ
+        let base64_image = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+        let image_bytes = base64::decode(base64_image).unwrap();
+
+        let text_overlay = TextOverlay {
+            text: "Test".to_string(),
+            color: DomainColor::new(255,0,0,255),
+            position: DomainPosition::Center,
+        };
+
+        let result = processor.add_text_to_image(
+            image_bytes,
+            Some(ImageFormat::Png), // 入力フォーマットを指定
+            &text_overlay,
+            ImageFormat::Png // 出力フォーマットを指定
+        );
+        assert!(result.is_ok());
+        if let Ok(output_bytes) = result {
+            assert!(!output_bytes.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_add_text_to_image_invalid_image_data() {
+        let processor = DefaultImageProcessor::new();
+        let invalid_image_bytes = vec![1, 2, 3, 4]; // 明らかに不正な画像データ
+
+        let text_overlay = TextOverlay {
+            text: "Test".to_string(),
+            color: DomainColor::new(255,0,0,255),
+            position: DomainPosition::Center,
+        };
+
+        let result = processor.add_text_to_image(
+            invalid_image_bytes,
+            None, // フォーマット推測させる
+            &text_overlay,
+            ImageFormat::Png
+        );
+        assert!(result.is_err());
+        if let Err(e) = result {
+            println!("Got expected error for invalid image data: {:?}", e);
+            match e {
+                InfrastructureError::ImageLibError(_) => {} // OK
+                // It could also be IoError if the format guessing fails at that stage
+                InfrastructureError::IoError(_) => {} // Also OK
+                _ => panic!("Expected ImageLibError or IoError for invalid image data, got {:?}", e),
+            }
+        }
+    }
+}

--- a/src/create_lgtm_image/infrastructure/mod.rs
+++ b/src/create_lgtm_image/infrastructure/mod.rs
@@ -1,0 +1,5 @@
+pub mod axum_handler;
+pub mod image_processor;
+pub mod file_storage;
+pub mod external_image_fetcher;
+pub mod error;

--- a/src/create_lgtm_image/main.rs
+++ b/src/create_lgtm_image/main.rs
@@ -1,20 +1,26 @@
+// main.rs
+pub mod domain;
+pub mod application;
+pub mod infrastructure;
+
+use std::sync::Arc;
 use axum::{
-    body::Body, extract::{Multipart, Query}, http::{self, StatusCode}, response::{IntoResponse, Response}, routing::{get, post}, Json, Router
+    routing::{get, post},
+    Router,
+    http::header::HeaderName, // axum::http::header::HeaderName に修正
 };
-use image::io::Reader as ImageReader;
-use image::{ImageFormat, Rgba, RgbaImage};
-use imageproc::drawing::draw_text_mut;
-use rusttype::{Font, Scale, point};
-use serde::Deserialize;
-use std::fs;
-use std::io::Cursor;
-use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
 use tower_http::cors::{CorsLayer, Any};
 use tower_http::services::ServeDir;
-use reqwest;
-use http::header::HeaderName;
-use base64::decode;
+
+use infrastructure::axum_handler::{
+    upload_image_handler,
+    preview_image_handler,
+    download_image_handler,
+    fetch_image_handler,
+    AppState,
+};
+use application::lgtm_service::LgtmService;
+use infrastructure::image_processor::DefaultImageProcessor; // LgtmServiceに渡すために必要
 
 #[tokio::main]
 async fn main() {
@@ -22,216 +28,30 @@ async fn main() {
         .allow_origin(Any)
         .allow_headers(vec![HeaderName::from_static("content-type")]);
 
+    // ImageProcessor のインスタンスを作成
+    let image_processor = Arc::new(DefaultImageProcessor::new());
+
+    // LgtmService のインスタンスを作成し、ImageProcessor を注入
+    let lgtm_service = Arc::new(LgtmService::new(image_processor));
+
+    // AppState の初期化 (image_processor フィールドはもうない)
+    let app_state = Arc::new(AppState {
+        lgtm_service, // LgtmService のインスタンスを渡す
+        // file_storage: Arc::new(LocalFileStorage::new()), // 必要なら
+    });
+
     let app = Router::new()
         .nest_service("/", ServeDir::new("frontend/build"))
-        .route("/upload", post(upload_image))
-        .route("/preview", get(preview_image))
-        .route("/download", get(download_image))
-        .route("/fetch", post(fetch_image))
+        .route("/upload", post(upload_image_handler))
+        .route("/preview", get(preview_image_handler))
+        .route("/download", get(download_image_handler))
+        .route("/fetch", post(fetch_image_handler))
+        .with_state(app_state)
         .layer(cors);
 
-    // サーバーの開始
+    println!("Server starting on 0.0.0.0:3300");
     axum::Server::bind(&"0.0.0.0:3300".parse().unwrap())
         .serve(app.into_make_service())
         .await
         .unwrap();
-}
-
-// 画像プレビュー用のエンドポイント
-async fn preview_image() -> Result<impl IntoResponse, (StatusCode, &'static str)> {
-    let image_path = "output.png"; // 作成した画像のパス
-    let image_data = fs::read(image_path).map_err(|_| (StatusCode::NOT_FOUND, "Image not found"))?;
-    
-    Ok(Response::builder()
-        .header("Content-Type", "image/png")
-        .body(Body::from(image_data))
-        .unwrap())
-}
-
-// 画像ダウンロード用のエンドポイント
-async fn download_image() -> Result<impl IntoResponse, (StatusCode, &'static str)> {
-    // 画像のパス
-    let image_path = "output.png";
-    
-    // 画像のバイナリデータを読み込んでレスポンスとして返す
-    let image_data = fs::read(image_path)
-        .map_err(|_| (StatusCode::NOT_FOUND, "Image not found"))?;
-    
-    // バイナリデータをレスポンスとして返す
-    Ok(Response::builder()
-        .header("Content-Type", "image/png")
-        .header("Content-Disposition", "attachment; filename=\"downloaded_image.png\"")
-        .body(Body::from(image_data))
-        .unwrap())
-}
-
-// 画像アップロード用のエンドポイント
-async fn upload_image(mut multipart: Multipart) -> impl IntoResponse {
-    while let Some(field) = multipart.next_field().await.unwrap() {
-        let data = field.bytes().await.unwrap();
-
-        let reader = ImageReader::new(Cursor::new(data)).with_guessed_format().expect("フォーマット判定失敗");
-        println!("Decord format: {:?}", reader.format());
-        let img = reader.decode().expect("画像のデコード失敗");
-
-        let mut img = img.to_rgba8();
-        add_text(&mut img, "LGTM", "#FFFFFFFF", "center");
-
-        // 画像を適切なフォーマットで保存
-        let mut file = File::create("output.png").await.unwrap();
-        let mut buffer = Cursor::new(Vec::new());
-        img.write_to(&mut buffer, ImageFormat::Png).expect("画像の保存失敗");
-
-        file.write_all(&buffer.into_inner()).await.unwrap();
-    }
-
-    "画像アップロード完了"
-}
-
-// 画像URLから画像を取得して表示するエンドポイント
-#[derive(Deserialize)]
-struct FetchImageParams {
-    url: String,
-    text: Option<String>,
-    #[serde(rename = "textColor")]
-    text_color: Option<String>,
-    #[serde(rename = "textPosition")]
-    text_position: Option<String>,
-    #[serde(rename = "outputFormat")]
-    output_format: Option<String>,
-}
-
-async fn fetch_image(Json(params): Json<FetchImageParams>) -> Result<impl IntoResponse, (StatusCode, &'static str)> {
-    let url = &params.url;
-    let actual_text = params.text.unwrap_or_else(|| "LGTM".to_string());
-    let actual_color = params.text_color.unwrap_or_else(|| "#FFFFFFFF".to_string());
-    let actual_position = params.text_position.unwrap_or_else(|| "center".to_string());
-    let desired_format_str = params.output_format.unwrap_or_else(|| "png".to_string()).to_lowercase();
-
-    let (image_format_enum, content_type_str) = match desired_format_str.as_str() {
-        "jpeg" | "jpg" => (ImageFormat::Jpeg, "image/jpeg"),
-        "png" | _ => (ImageFormat::Png, "image/png"), // Default to PNG
-    };
-    let bytes = if url.starts_with("data:") {
-        // dataスキームを解析
-        let base64_data = url.split(',').nth(1).ok_or((StatusCode::BAD_REQUEST, "Invalid data URL"))?;
-        decode(base64_data).map_err(|_| (StatusCode::BAD_REQUEST, "Failed to decode base64 data"))?
-    } else {
-        // 通常のURLから画像を取得
-        let response = reqwest::get(url).await.map_err(|e| {
-            println!("Failed to fetch image: {:?}", e); // エラーメッセージを詳細に出力
-            (StatusCode::BAD_REQUEST, "Failed to fetch image")
-        })?;
-        response.bytes().await.map_err(|e| {
-            println!("Failed to read image: {:?}", e); // エラーメッセージを詳細に出力
-            (StatusCode::BAD_REQUEST, "Failed to read image")
-        })?.to_vec()
-    };
-
-    let reader = ImageReader::new(Cursor::new(bytes)).with_guessed_format().expect("フォーマット判定失敗");
-    let img = reader.decode().expect("画像のデコード失敗");
-
-    let mut img = img.to_rgba8();
-    add_text(&mut img, &actual_text, &actual_color, &actual_position);
-
-    let mut buffer = Cursor::new(Vec::new());
-    img.write_to(&mut buffer, image_format_enum).expect("画像の保存失敗");
-
-    Ok(Response::builder()
-        .header("Content-Type", content_type_str)
-        .body(Body::from(buffer.into_inner()))
-        .unwrap())
-}
-
-fn add_text(img: &mut RgbaImage, text: &str, color_hex: &str, position: &str) {
-    let font_data = include_bytes!("../../DejaVu_Sans/DejaVuSans-Bold.ttf");
-    let font = Font::try_from_bytes(font_data).expect("フォントの読み込み失敗");
-
-    let color = parse_hex_color(color_hex);
-
-    // Initial font scale based on image height.
-    // Adjusted for very long text to prevent excessively small font from the start.
-    let mut current_scale_val = if text.len() > 20 { // Heuristic for "very long"
-        img.height() as f32 / (text.len() as f32 / 2.5) // More aggressive scaling down for long text
-    } else if text.len() > 10 {
-        img.height() as f32 / (text.len() as f32 / 1.8) // Moderate scaling for medium text
-    } else {
-        img.height() as f32 / 5.0 // Default for short text
-    };
-    // Ensure scale is not excessively small or zero if image height is tiny or text extremely long
-    if current_scale_val < 1.0 { current_scale_val = 1.0; }
-
-    let mut scale = Scale::uniform(current_scale_val);
-
-    // Calculate text width and height with this initial scale
-    let mut v_metrics = font.v_metrics(scale);
-    let mut glyphs: Vec<_> = font.layout(text, scale, point(0.0, 0.0)).collect();
-    let mut text_width = glyphs.iter().filter_map(|g| g.pixel_bounding_box()).map(|bb| bb.max.x as f32).last().unwrap_or(0.0);
-    let mut text_height = v_metrics.ascent - v_metrics.descent; // Full height of the text block
-
-    // Adjust scale if text width is too large for the image (e.g., > 90% of image width)
-    let max_text_width_ratio = 0.90;
-    if text_width > img.width() as f32 * max_text_width_ratio && text_width > 0.0 {
-        let new_scale_factor = (img.width() as f32 * max_text_width_ratio) / text_width;
-        current_scale_val *= new_scale_factor;
-        if current_scale_val < 1.0 { current_scale_val = 1.0; } // Prevent scale from becoming too small
-        scale = Scale::uniform(current_scale_val);
-
-        // Recalculate metrics with the new, adjusted scale
-        v_metrics = font.v_metrics(scale);
-        glyphs = font.layout(text, scale, point(0.0, 0.0)).collect();
-        text_width = glyphs.iter().filter_map(|g| g.pixel_bounding_box()).map(|bb| bb.max.x as f32).last().unwrap_or(0.0);
-        text_height = v_metrics.ascent - v_metrics.descent;
-    }
-
-    let final_scale = scale;
-    let v_metrics_final = v_metrics; // Use the potentially adjusted v_metrics
-    let actual_text_glyph_height = text_height; // Height of the text glyphs based on final scale
-
-    // Calculate base x and y for text drawing based on position string
-    let (mut x_pos, mut y_pos_base) = match position {
-        "top-left" => (0.0, 0.0),
-        "top-center" => ((img.width() as f32 - text_width) / 2.0, 0.0),
-        "top-right" => (img.width() as f32 - text_width, 0.0),
-        "center-left" => (0.0, (img.height() as f32 - actual_text_glyph_height) / 2.0),
-        "center" => ((img.width() as f32 - text_width) / 2.0, (img.height() as f32 - actual_text_glyph_height) / 2.0),
-        "center-right" => (img.width() as f32 - text_width, (img.height() as f32 - actual_text_glyph_height) / 2.0),
-        "bottom-left" => (0.0, img.height() as f32 - actual_text_glyph_height),
-        "bottom-center" => ((img.width() as f32 - text_width) / 2.0, img.height() as f32 - actual_text_glyph_height),
-        "bottom-right" => (img.width() as f32 - text_width, img.height() as f32 - actual_text_glyph_height),
-        _ => ((img.width() as f32 - text_width) / 2.0, (img.height() as f32 - actual_text_glyph_height) / 2.0), // Default
-    };
-
-    // Ensure x_pos is not negative (can happen if text_width is slightly larger than image due to approximations)
-    if x_pos < 0.0 { x_pos = 0.0; }
-    if y_pos_base < 0.0 {y_pos_base = 0.0; }
-
-
-    // Adjust y_pos to account for font ascent (baseline for drawing)
-    let y_pos = y_pos_base + v_metrics_final.ascent;
-
-    draw_text_mut(img, color, x_pos as i32, y_pos as i32, final_scale, &font, text);
-}
-
-// Helper function to parse hex color string
-fn parse_hex_color(hex_str: &str) -> Rgba<u8> {
-    let hex = hex_str.trim_start_matches('#');
-    let default_color = Rgba([255, 255, 255, 255]); // White
-
-    match hex.len() {
-        6 => { // RRGGBB
-            let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255);
-            let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255);
-            let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255);
-            Rgba([r, g, b, 255])
-        }
-        8 => { // RRGGBBAA
-            let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255);
-            let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255);
-            let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255);
-            let a = u8::from_str_radix(&hex[6..8], 16).unwrap_or(255);
-            Rgba([r, g, b, a])
-        }
-        _ => default_color, // Invalid length
-    }
 }


### PR DESCRIPTION
This commit refactors the existing LGTM image generation application to align with Clean Architecture principles (Domain, Application, Infrastructure layers) and SOLID principles.

Key changes include:
- Separation of concerns into distinct layers:
    - Domain: Core business logic and entities.
    - Application: Use case specific services.
    - Infrastructure: Framework-specific details, external library integrations (image processing, HTTP handling), etc.
- Defined traits for abstractions (e.g., ImageProcessor) and implemented them in the infrastructure layer.
- Improved error handling with custom error types using `thiserror` and centralized HTTP error responses.
- Added unit tests for domain logic (DefaultImageProcessor) and application services (LgtmService) using manual mocks.
- Reorganized code structure for better maintainability and testability.